### PR TITLE
Add imdecode support

### DIFF
--- a/opencv.cc
+++ b/opencv.cc
@@ -250,6 +250,7 @@ const zend_function_entry opencv_functions[] = {
     ZEND_NS_NAMED_FE(OPENCV_DNN_NS, readNetFromCaffe, ZEND_FN(opencv_dnn_read_net_from_caffe), NULL)
     ZEND_NS_NAMED_FE(OPENCV_DNN_NS, readNetFromTorch, ZEND_FN(opencv_dnn_read_net_from_torch), NULL)
     ZEND_NS_NAMED_FE(OPENCV_DNN_NS, readNetFromTensorflow, ZEND_FN(opencv_dnn_read_net_from_tensorflow), NULL)
+    ZEND_NS_NAMED_FE(OPENCV_NS, imdecode, ZEND_FN(opencv_imdecode), NULL)
 	PHP_FE_END	/* Must be the last line in opencv_functions[] */
 };
 /* }}} */

--- a/source/opencv2/opencv_imgcodecs.cc
+++ b/source/opencv2/opencv_imgcodecs.cc
@@ -99,7 +99,7 @@ PHP_FUNCTION(opencv_imdecode)
     object_init_ex(&instance,opencv_mat_ce);
     opencv_mat_object *obj = Z_PHP_MAT_OBJ_P(&instance);
 
-    Mat im = imdecode(Mat(1, buf_len, CV_8UC1, buf), CV_LOAD_IMAGE_UNCHANGED);
+    Mat im = imdecode(Mat(1, buf_len, CV_8UC1, buf), (int)flags);
     if(im.empty() || !im.data){
         char *error_message = (char*)malloc(strlen("Can not load image") + 1);
         strcpy(error_message,"Can not load image");

--- a/source/opencv2/opencv_imgcodecs.cc
+++ b/source/opencv2/opencv_imgcodecs.cc
@@ -80,6 +80,40 @@ PHP_FUNCTION(opencv_imwrite){
     RETURN_TRUE;
 }
 
+/**
+ * CV\imdecode
+ * @param execute_data
+ * @param return_value
+ */
+PHP_FUNCTION(opencv_imdecode)
+{
+    long flags;
+    char *buf;
+    long buf_len;
+    flags = IMREAD_COLOR;//flags default value
+
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "s|l", &buf,&buf_len, &flags) == FAILURE) {
+        RETURN_NULL();
+    }
+    zval instance;
+    object_init_ex(&instance,opencv_mat_ce);
+    opencv_mat_object *obj = Z_PHP_MAT_OBJ_P(&instance);
+
+    Mat im = imdecode(Mat(1, buf_len, CV_8UC1, buf), CV_LOAD_IMAGE_UNCHANGED);
+    if(im.empty() || !im.data){
+        char *error_message = (char*)malloc(strlen("Can not load image") + 1);
+        strcpy(error_message,"Can not load image");
+        opencv_throw_exception(error_message);//throw exception
+        free(error_message);
+    }
+
+    obj->mat = new Mat(im);
+
+    //update php Mat object property
+    opencv_mat_update_property_by_c_mat(&instance, obj->mat);
+
+    RETURN_ZVAL(&instance,0,0); //return php Mat object
+}
 
 void opencv_imgcodecs_init(int module_number)
 {

--- a/source/opencv2/opencv_imgcodecs.h
+++ b/source/opencv2/opencv_imgcodecs.h
@@ -20,5 +20,6 @@
 extern void opencv_imgcodecs_init(int module_number);
 PHP_FUNCTION(opencv_imread);
 PHP_FUNCTION(opencv_imwrite);
+PHP_FUNCTION(opencv_imdecode);
 
 #endif //OPENCV_OPENCV_IMCODECS_H

--- a/tests/faceRecognizerDecode.phpt
+++ b/tests/faceRecognizerDecode.phpt
@@ -1,0 +1,42 @@
+--TEST--
+LBPHFaceRecognizer with Decode
+--SKIPIF--
+<?php if (!extension_loaded("opencv")) print "skip"; ?>
+--FILE--
+<?php
+use CV\Face\LBPHFaceRecognizer;
+use function CV\{imdecode, cvtColor, equalizeHist};
+use const CV\{COLOR_BGR2GRAY};
+
+$faceRecognizer = LBPHFaceRecognizer::create();
+
+//hihozhou
+$str = file_get_contents('./tests/face_recognizer.jpg');
+$src = imdecode($str);
+$gray = cvtColor($src, COLOR_BGR2GRAY);
+equalizeHist($gray, $gray);
+
+$faceRecognizer->train([$gray], [1]);
+
+//Obama
+$str = file_get_contents('./tests/Obama.png');
+$src = imdecode($str);
+$gray = cvtColor($src, COLOR_BGR2GRAY);
+equalizeHist($gray, $gray);
+
+//Obama grey
+$faceRecognizer->train([$gray], [41]);
+
+$str = file_get_contents('./tests/Obama_gray.png');
+$src = imdecode($str);
+$gray = cvtColor($src, COLOR_BGR2GRAY);
+equalizeHist($gray, $gray);
+
+$faceLabel = $faceRecognizer->predict($gray, $faceConfidence);
+
+$faceLabel = $faceRecognizer->predict($gray);
+
+echo "{$faceLabel}";
+?>
+--EXPECT--
+41


### PR DESCRIPTION
I needed the option to process an image already loaded into a string so I added the opencv `imdecode` function.

I've added a test function, it runs the same `LBPHFaceRecognizer` tests but with the images loaded using `imdecode` instead of `imread`. 

